### PR TITLE
Move to chart dependency

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,6 @@
+chart-dir: helm/karpenter
+replace-chart-version-with-git: true
+replace-app-version-with-git: false
+generate-metadata: true
+catalog-base-url: https://giantswarm.github.io/giantswarm-catalog/
+ct-config: ./.circleci/ct-config.yml

--- a/helm/karpenter/Chart.yaml
+++ b/helm/karpenter/Chart.yaml
@@ -16,3 +16,10 @@ sources:
   - https://github.com/aws/karpenter/
 annotations:
   application.giantswarm.io/team: phoenix
+dependencies:
+  - name: karpenter
+    version: v0.27.0
+    repository: oci://public.ecr.aws/karpenter
+maintainers:
+  - name: giantswarm/team-phoenix
+    email: team-phoenix@giantswarm.io


### PR DESCRIPTION
This PR:

moves to chart dependency as per https://intranet.giantswarm.io/docs/dev-and-releng/how-to-migrate-to-chart-dependency/