### PR TITLE
Add `giantswarm.io/cluster` AWS tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enable consolidation in the Provisioner
+- Add `giantswarm.io/cluster` AWS tag for unified overview in AWS cost explorer
 
 ## [0.1.0] - 2023-06-08
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ spec:
       managed-by: karpenter
       nodepool: <NODEPOOL_ID>
       cluster: <CLUSTER_ID>
+      giantswarm.io/cluster: <CLUSTER_ID>
       Name: <CLUSTER_ID>-karpenter-spot-worker
 ```
 


### PR DESCRIPTION
This PR adds the `giantswarm.io/cluster` AWS tag for unified overview in AWS cost explorer