### PR TITLE
Use latest available flowcontrol version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Detect and use latest `flowcontrol` API version.
+
 ## [0.12.1] - 2024-05-09
 
 ### Changed

--- a/helm/karpenter/templates/flowschema.yaml
+++ b/helm/karpenter/templates/flowschema.yaml
@@ -1,6 +1,12 @@
 {{ if .Values.flowSchema.leaderElection.create }}
 ---
+{{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1"}}
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" }}
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+{{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+{{- end }}
 kind: FlowSchema
 metadata:
   name: karpenter-leader-election
@@ -36,7 +42,13 @@ spec:
 {{- end -}}
 {{ if .Values.flowSchema.workload.create }}
 ---
+{{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1"}}
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" }}
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+{{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+{{- end }}
 kind: FlowSchema
 metadata:
   name: karpenter-workload


### PR DESCRIPTION
v1beta2 is deprecated. v1beta3 is available in kubernetes 1.26 and v1 from 1.29

This PR:

adds/changes/removes etc
Checklist
- [x] Update changelog in CHANGELOG.md.
- [x] Make sure values.yaml and values.schema.json are valid.