### PR TITLE
Fix Karpenter PodDisruptionBudget - Set correct renewer labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set the correct `app.kubernetes.io/instance` label to `karpenter-renewer`. This fixes the Karpenter PodDisruptionBudget
+- Set the correct `app.kubernetes.io/instance` label to `karpenter-renewer`. This fixes the Karpenter `PodDisruptionBudget` pod selection.
 
 ## [0.9.3] - 2024-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set the correct `app.kubernetes.io/instance` label to `karpenter-renewer`. This fixes the Karpenter PodDisruptionBudget
+
 ## [0.9.3] - 2024-02-06
 
 ## [0.9.2] - 2024-02-05

--- a/helm/karpenter/templates/node-renewer.yaml
+++ b/helm/karpenter/templates/node-renewer.yaml
@@ -56,6 +56,7 @@ metadata:
   name: {{ include "karpenter.serviceAccountName" . }}-renewer
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
+    app.kubernetes.io/instance: karpenter-renewer
 spec:
   schedule: "{{ .Values.renewerCronjob.schedule }}"
   jobTemplate:
@@ -63,8 +64,8 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/instance: karpenter-renewer
             {{- include "karpenter.labels" . | nindent 12 }}
+            app.kubernetes.io/instance: karpenter-renewer
         spec:
           serviceAccountName: {{ include "karpenter.serviceAccountName" . }}-renewer
           restartPolicy: OnFailure


### PR DESCRIPTION
This PR:

Set the correct `app.kubernetes.io/instance` label to karpenter-renewer

The renewer Job had the same `app.kubernetes.io/instance` label as the main karpenter controller, this was messing up the Karpenter PDB, preventing disruption to any of the two deployment replicas.

This PR will only be applied to `release-v0.9.x` branch, since the karpenter-renewer CronJob got removed in newer releases. But version 0.9.x is still in use on some Vintage clusters.

adds/changes/removes etc
Checklist
 - [x] Update changelog in CHANGELOG.md.
 - [x] Make sure values.yaml and values.schema.json are valid.