### PR TITLE
Add `iam:GetInstanceProfile` permission to Karpenter IAM role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `cluster.x-k8s.io/cluster-name` label to the karpenter HelmRelease.
+- Add `iam:GetInstanceProfile` permission to Karpenter IAM role.
 
 ### Changed
 

--- a/helm/karpenter-bundle/templates/iam.yaml
+++ b/helm/karpenter-bundle/templates/iam.yaml
@@ -51,7 +51,8 @@ spec:
                   "ec2:DescribeSubnets",
                   "pricing:GetProducts",
                   "ssm:GetParameter",
-                  "iam:ListInstanceProfiles"
+                  "iam:ListInstanceProfiles",
+                  "iam:GetInstanceProfile"
                 ]
               },
               {


### PR DESCRIPTION
This is required by Karpenter when deleting EC2NodeClasses
