### PR TITLE
Add karpenter CRDs to Chart.yaml and update changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,0 @@
-
-The contents of this repository are mostly generated from the `karpenter` fork that we maintain at https://github.com/giantswarm/karpenter-provider-aws-upstream.
-If you want to do changes to the app, please do so in that repository and then run `make build` to update the contents of this repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `cluster.x-k8s.io/cluster-name` label to the karpenter HelmRelease.
+- Add karpenter CRDs.
 
 ### Changed
 

--- a/helm/karpenter/Chart.lock
+++ b/helm/karpenter/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: karpenter
   repository: oci://public.ecr.aws/karpenter
   version: 1.8.1
-digest: sha256:edd8adecaa97627f915d720b11e2ae64581bee81ae3a8bbb6bae7de837a39b6a
-generated: "2026-03-04T11:40:52.819403+01:00"
+- name: karpenter-crd
+  repository: oci://public.ecr.aws/karpenter
+  version: 1.8.1
+digest: sha256:a97ad8503c31482525f66c6283f3e842487b5ccbd942efc674d6ad13e72284d9
+generated: "2026-04-28T11:16:15.067156+02:00"

--- a/helm/karpenter/Chart.yaml
+++ b/helm/karpenter/Chart.yaml
@@ -32,4 +32,4 @@ dependencies:
   - name: karpenter-crd
     alias: upstream-crd
     version: "1.8.1"
-    repository: "oci://public.ecr.aws/karpenter-crd"
+    repository: "oci://public.ecr.aws/karpenter"

--- a/helm/karpenter/Chart.yaml
+++ b/helm/karpenter/Chart.yaml
@@ -29,3 +29,7 @@ dependencies:
     alias: upstream
     version: "1.8.1"
     repository: "oci://public.ecr.aws/karpenter"
+  - name: karpenter-crd
+    alias: upstream-crd
+    version: "1.8.1"
+    repository: "oci://public.ecr.aws/karpenter-crd"


### PR DESCRIPTION
The contents of this repository are mostly generated from the `karpenter` fork that we maintain at https://github.com/giantswarm/karpenter-provider-aws-upstream.
If you want to do changes to the app, please do so in that repository and then run `make build` to update the contents of this repository.
