### PR TITLE
Set helm.sh/resource-policy: keep on karpenter CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `cluster.x-k8s.io/cluster-name` label to the karpenter HelmRelease.
 - Add `iam:GetInstanceProfile` permission to Karpenter IAM role.
 - Add karpenter CRDs.
+- Set `helm.sh/resource-policy: keep` on the karpenter CRDs so they survive HelmRelease uninstall and prevent cascade-deleting `NodePool`/`NodeClaim`/`EC2NodeClass` resources.
 
 ### Changed
 

--- a/helm/karpenter/values.yaml
+++ b/helm/karpenter/values.yaml
@@ -9,6 +9,13 @@ upstream:
       resources: ["nodes/finalizers"]
       verbs: ["update"]
 
+upstream-crd:
+  additionalAnnotations:
+    # Prevent Helm from cascade-deleting NodePools/NodeClaims/EC2NodeClasses
+    # if the HelmRelease is ever uninstalled. The pre-2.3.0 forked CRDs had
+    # this annotation; the upstream karpenter-crd chart does not set it.
+    helm.sh/resource-policy: keep
+
 # ─── EXTRAS ──────────────────────────────────────────────────────────────────
 podLogs:
   enabled: false


### PR DESCRIPTION
## Summary

- The upstream `karpenter-crd` chart does not set `helm.sh/resource-policy: keep`. Without it, deleting/uninstalling the karpenter HelmRelease would cascade-delete the CRDs and, with them, every `NodePool`, `NodeClaim` and `EC2NodeClass` in the workload cluster.
- This restores parity with the pre-2.3.0 forked chart (which did set the annotation) by passing it through the upstream chart's `additionalAnnotations` hook from `helm/karpenter/values.yaml`.
- Adoption of existing CRDs in clusters previously rendered by this HelmRelease still works — Helm matches on `meta.helm.sh/release-name`/`release-namespace`, which are unchanged regardless of which subchart the manifest comes from.

## Test plan

- [ ] `helm dependency update helm/karpenter` && `helm template` shows `helm.sh/resource-policy: keep` on all four CRDs (`nodepools.karpenter.sh`, `nodeclaims.karpenter.sh`, `nodeoverlays.karpenter.sh`, `ec2nodeclasses.karpenter.k8s.aws`).
- [ ] Install on a fresh cluster: CRDs created with the keep annotation.
- [ ] Upgrade on a cluster that has CRDs from the pre-2.3.0 forked chart: Helm adopts the existing CRDs, annotation present, no `invalid ownership metadata` error.
- [ ] Uninstall the HelmRelease: CRDs and any `NodePool`/`NodeClaim`/`EC2NodeClass` survive.