### PR TITLE
chore(pss): Remove PSP-related leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `global.podSecurityStandards.enforced` helm value. The Kyverno `PolicyException` in `pss-exceptions.yaml` is now rendered unconditionally.
+
 ## [2.4.0] - 2026-04-28
 
 ### Added

--- a/helm/karpenter-bundle/templates/_helpers.tpl
+++ b/helm/karpenter-bundle/templates/_helpers.tpl
@@ -184,7 +184,7 @@ Routes upstream values under `upstream:` key and extras at top level.
 {{/* Keys that belong to the bundle chart itself (never forwarded) */}}
 {{- $bundleOnlyKeys := list "ociRepositoryUrl" "clusterID" "region" "workersIamRole" -}}
 {{/* Keys forwarded as workload extras (not under upstream:) */}}
-{{- $extrasKeys := list "podLogs" "global" -}}
+{{- $extrasKeys := list "podLogs" -}}
 {{/* Keys with special handling */}}
 {{- $specialKeys := list "controller" "proxy" -}}
 {{- $reservedKeys := concat $bundleOnlyKeys $extrasKeys $specialKeys -}}
@@ -226,7 +226,6 @@ Routes upstream values under `upstream:` key and extras at top level.
 {{/* Assemble workload values: upstream + extras */}}
 {{- $workloadValues := dict "upstream" $upstreamValues -}}
 {{- $_ := set $workloadValues "podLogs" .Values.podLogs -}}
-{{- $_ := set $workloadValues "global" .Values.global -}}
 
 {{- $workloadValues | toYaml -}}
 {{- end -}}

--- a/helm/karpenter-bundle/values.yaml
+++ b/helm/karpenter-bundle/values.yaml
@@ -43,7 +43,3 @@ proxy:
 podLogs:
   enabled: false
   tenant: ""
-
-global:
-  podSecurityStandards:
-    enforced: false

--- a/helm/karpenter/templates/pss-exceptions.yaml
+++ b/helm/karpenter/templates/pss-exceptions.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.podSecurityStandards.enforced }}
 {{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
 apiVersion: kyverno.io/v2
 {{- else }}
@@ -65,4 +64,3 @@ spec:
             - {{ .Release.Namespace }}
           names:
             - karpenter*
-{{- end }}

--- a/helm/karpenter/values.schema.json
+++ b/helm/karpenter/values.schema.json
@@ -10,10 +10,6 @@
         "podLogs": {
             "type": "object",
             "additionalProperties": true
-        },
-        "global": {
-            "type": "object",
-            "additionalProperties": true
         }
     }
 }

--- a/helm/karpenter/values.yaml
+++ b/helm/karpenter/values.yaml
@@ -20,7 +20,3 @@ upstream-crd:
 podLogs:
   enabled: false
   tenant: ""
-
-global:
-  podSecurityStandards:
-    enforced: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35177

- `helm/karpenter/templates/pss-exceptions.yaml`: drop the `{{- if .Values.global.podSecurityStandards.enforced }}` guard so the `PolicyException` always renders.
- `helm/karpenter/values.yaml`, `helm/karpenter-bundle/values.yaml`: remove the `global.podSecurityStandards` block.
- `helm/karpenter/values.schema.json`: remove the `global` property.
- `helm/karpenter-bundle/templates/_helpers.tpl`: drop `global` from `$extrasKeys` and from the workload-values assembly in `giantswarm.workloadValues`.
